### PR TITLE
Handle deletes and misses due to caching.

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,19 +6,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/respawner/peeringdb"
 )
 
 const dbSchema = `
-CREATE TABLE last_sync (
-  id      integer  NOT NULL PRIMARY KEY AUTOINCREMENT,
-  updated datetime NOT NULL
-);
-INSERT INTO last_sync VALUES (0, 0);
-
 CREATE TABLE peeringdb_facility (
   id       integer      NOT NULL PRIMARY KEY AUTOINCREMENT,
   status   varchar(255) NOT NULL,
@@ -243,11 +236,7 @@ func main() {
 	// Prepare to query the API and the synchronization
 	sync := synchronization{peeringdb.NewAPI(), db}
 
-	var lastSync int64
-	if !initialSynchronization {
-		// Found the last database sync
-		lastSync = sync.getLastSyncDate()
-	} else {
+	if initialSynchronization {
 		// First time, create the database schema
 		_, err = db.Exec(dbSchema)
 		if err != nil {
@@ -259,19 +248,16 @@ func main() {
 	fmt.Println("Starting PeeringDB synchronization...")
 
 	// Synchronize all objects
-	sync.synchronizeOrganizations(lastSync)
-	sync.synchronizeFacilities(lastSync)
-	sync.synchronizeNetworks(lastSync)
-	sync.synchronizeInternetExchanges(lastSync)
-	sync.synchronizeInternetExchangeFacilities(lastSync)
-	sync.synchronizeInternetLANs(lastSync)
-	sync.synchronizeInternetPrefixes(lastSync)
-	sync.synchronizeNetworkContacts(lastSync)
-	sync.synchronizeNetworkFacilities(lastSync)
-	sync.synchronizeNetworkInternetExchangeLANs(lastSync)
-
-	// Set the last sync date
-	sync.setLastSyncDate(time.Now().Unix())
+	sync.synchronizeOrganizations()
+	sync.synchronizeFacilities()
+	sync.synchronizeNetworks()
+	sync.synchronizeInternetExchanges()
+	sync.synchronizeInternetExchangeFacilities()
+	sync.synchronizeInternetLANs()
+	sync.synchronizeInternetPrefixes()
+	sync.synchronizeNetworkContacts()
+	sync.synchronizeNetworkFacilities()
+	sync.synchronizeNetworkInternetExchangeLANs()
 
 	fmt.Println("PeeringDB fully synchronized.")
 }


### PR DESCRIPTION
I realise this is ancient code that probably few people actually use, but I
was wondering why this code was failing for an old copy of the database
I had lying around, and discovered a few little fixes I could quickly make.

Deletes were never handled, so there's now a quick check for records
with the status of "deleted" which should be purged from the database.
Ideally this would be done when the update phase is happening to
needlessly write the deleted entry first, but it would be quite
difficult due to the way that code is written... So this works!

When it comes to caching, a query to PeeringDB goes directly through the
application and to the database, except when you request all the records
(the "since" parameter is set to zero) when for reasons of lower load it
serves up a stored copy that may be up to 15 minutes old.

Rather than storing the time the last sync was completed (and therefore
potentially missing some records that may have been added / changed
since the cache was generated) we now just look for the timestamp of the
last record to be updated, and tell PeeringDB to give us everything
since then.

This has the unfortunate effect of needlessly performing an insert /
delete cycle if the only fetched records are deleted, but I can live
with that for now!